### PR TITLE
add vercel deploy url to socket origins

### DIFF
--- a/socketIOSetup/socketIOSetup.js
+++ b/socketIOSetup/socketIOSetup.js
@@ -1,9 +1,13 @@
 import { Server } from 'socket.io';
 
 export default function socketIOSetup(server) {
+  const PRODUCTION_URL = 'https://www.frempco.com';
+  const DEV_URL = 'http://localhost:3000';
+  const VERCEL_DEPLOY_PREVIEW_URL = /https:..frempco.*vercel.app/;
+
   const io = new Server(server, {
     cors: {
-      origin: ['https://www.frempco.com', 'http://localhost:3000'],
+      origin: [PRODUCTION_URL, DEV_URL, VERCEL_DEPLOY_PREVIEW_URL],
     },
   });
 


### PR DESCRIPTION
Adds vercel preview urls to list of valid CORs using a RegEx expression

Test plan:
I ran this backend branch locally, then accessed the vercel preview url of https://frempco-git-setup-socketio-mssiegel.vercel.app and visited the teachers page and saw the socket id listed. 

![image](https://user-images.githubusercontent.com/29524485/144356174-0e87b409-4bc8-4455-b337-a4f74a4cd349.png)
