### PR TITLE
Added dev site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,17 @@
 
 Frempco lets teachers pair up classmates for text-based improvised chats. Students build up real-world friendships through collaboration and storytelling. The word "Frempco" stands for "Friendships + Empowerment = Community," the equation that powers what we do.
 
-## Live site
+## Hosting
 
-### [frempco.com](https://www.frempco.com/)
-
-- Front end hosted on Vercel
+- Dev site: [dev.frempco.com](https://dev.frempco.com/)
+- Live site: [frempco.com](https://www.frempco.com/)
+- Frontend hosted on Vercel
 - Backend hosted on Heroku
 
 ## Tech stack (backend)
 
 - Node / Express
+- TypeScript
 - SocketIO
 
 ## Setup instructions
@@ -19,3 +20,10 @@ Frempco lets teachers pair up classmates for text-based improvised chats. Studen
 1. `npm install`
 2. `npm run dev`
 3. Download the [frontend repo](https://github.com/mssiegel/frempco-client) and run it separately
+
+## Git workflow
+
+- Our production branch is `main`, and our development branch is `dev`
+- All development branches come from `dev`
+- Pull requests are merged into `dev`
+- Every so often, we merge `dev` into `main`

--- a/services/corsOptions.ts
+++ b/services/corsOptions.ts
@@ -1,9 +1,11 @@
+// Allowed client side URLs
 const PRODUCTION_URL = 'https://www.frempco.com';
-const DEV_URL = 'http://localhost:3000';
+const DEV_URL = 'https://dev.frempco.com';
+const LOCAL_URL = 'http://localhost:3000';
 const VERCEL_DEPLOY_PREVIEW_URL = /https:..frempco.*vercel.app/;
 
 const corsOptions = {
-  origin: [PRODUCTION_URL, DEV_URL, VERCEL_DEPLOY_PREVIEW_URL],
+  origin: [PRODUCTION_URL, DEV_URL, LOCAL_URL, VERCEL_DEPLOY_PREVIEW_URL],
 };
 
 export default corsOptions;


### PR DESCRIPTION
I setup a heroku dev backend (https://frempco-dev.herokuapp.com/) and connected it to our newly created backend `dev` branch

I added our Vercel dev site [dev.frempco.com](https://dev.frempco.com/) on Vercel to the list of allowed client side urls. 
I also updated our Readme. 

Once this PR is deployed, the frontend and backend dev urls should be fully connected!